### PR TITLE
Correct behavior, consistent style, bashisms

### DIFF
--- a/deck
+++ b/deck
@@ -13,8 +13,8 @@ fatal() { echo "fatal: $@" 1>&2; exit 1; }
 usage() {
 cat<<EOF
 Deck a filesystem using overlayfs (experimental)
-Syntax: $(basename $0) path/to/dir/or/deck path/to/new/deck
-Syntax: $(basename $0) [ -option ] path/to/existing/deck
+Syntax: $(basename "$0") path/to/dir/or/deck path/to/new/deck
+Syntax: $(basename "$0") [ -option ] path/to/existing/deck
 
 Options:
     -m|--mount      - mounts a deck (the default)
@@ -31,97 +31,100 @@ exit 1
 }
 
 deck_mount() {
-    local parent=$(realpath $1)
-    local mountpath=$(realpath $2)
-    [ -d $parent ] || fatal "parent does not exist"
+    local parent=$(realpath "$1")
+    local mountpath=$(realpath "$2")
+    [[ -d "$parent" ]] || fatal 'parent does not exist'
     
-    if [ -d $mountpath ]; then
-        [ "$(find $mountpath -maxdepth 0 -empty)" ] || \
-            fatal "mountpath exists but not empty"
+    if [[ -d "$mountpath" ]]; then
+        [[ -z $(find "$mountpath" -maxdepth 0 -empty) ]] || \
+            fatal 'mountpath exists but not empty'
     fi
 
-    local deckdir=$(dirname $mountpath)/.deck/$(basename $mountpath)
-    local workdir=$deckdir/work
-    local upperdir=$deckdir/upper
-    mkdir -p $deckdir $workdir $upperdir
+    local deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
+    local workdir="$deckdir/work"
+    local upperdir="$deckdir/upper"
+    mkdir -p "$deckdir" "$workdir" "$upperdir"
 
-    if deck_isdeck $parent; then
-        echo $parent > $deckdir/parent
-        local parent_deckdir=$(dirname $parent)/.deck/$(basename $parent)
-        cp $parent_deckdir/layers $deckdir/layers
-        echo -e "$parent_deckdir/upper\n$(cat $deckdir/layers)" > $deckdir/layers
-        deck_ismounted $parent && deck_umount $parent
+    if deck_isdeck "$parent"; then
+        echo "$parent" > "$deckdir/parent"
+        local parent_deckdir="$(dirname "$parent")/.deck/$(basename "$parent")"
+        cp "$parent_deckdir/layers" "$deckdir/layers"
+        sed -i "1i$parent_deckdir/upper" "$deckdir/layers"
+        deck_ismounted "$parent" && deck_umount "$parent"
     else
-        echo $parent > $deckdir/parent
-        echo $parent > $deckdir/layers
+        echo "$parent" > "$deckdir/parent"
+        echo "$parent" > "$deckdir/layers"
     fi
 
-    mkdir -p $mountpath
-    local lowerdir=$(cat $deckdir/layers | tr '\n' ':' | sed 's/:$//')
+    mkdir -p "$mountpath"
+    local lowerdir="$(cat "$deckdir/layers" | tr '\n' ':' | sed 's/:$//')"
     local options="lowerdir=$lowerdir,upperdir=$upperdir,workdir=$workdir"
-    mount -t overlay overlay -o $options $mountpath
+    mount -t overlay overlay -o "$options" "$mountpath"
 }
 
 deck_remount() {
-    local mountpath=$(realpath $1)
-    [ -d $mountpath ] || fatal "mountpath does not exists"
-    deck_ismounted $mountpath && fatal "already mounted"
-    deck_isdeck $mountpath || fatal "not a deck"
-    local deckdir=$(dirname $mountpath)/.deck/$(basename $mountpath)
-    local parent=$(cat $deckdir/parent)
-    deck_mount $parent $mountpath
+    local mountpath=$(realpath "$1")
+    [[ -d "$mountpath" ]] || fatal 'mountpath does not exist'
+    deck_ismounted "$mountpath" && fatal 'already mounted'
+    deck_isdeck "$mountpath" || fatal 'not a deck'
+    local deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
+    local parent=$(cat "$deckdir/parent")
+    deck_mount "$parent" "$mountpath"
 }
 
 deck_umount() {
-    local mountpath=$(realpath $1)
-    [ -d $mountpath ] || fatal "mountpath does not exist"
-    deck_ismounted $mountpath || fatal "not mounted"
-    umount $mountpath
+    local mountpath=$(realpath "$1")
+    [[ -d "$mountpath" ]] || fatal 'mountpath does not exist'
+    deck_ismounted "$mountpath" || fatal 'not mounted'
+    umount "$mountpath"
 }
 
 deck_delete() {
-    local mountpath=$(realpath $1)
-    local deckdir=$(dirname $mountpath)/.deck/$(basename $mountpath)
-    [ -d $mountpath ] || fatal "mountpath does not exists"
-    $(cat $(dirname $deckdir)/*/parent | grep -q "^${mountpath}$") && \
-        fatal "cannot delete a parent deck"
+    local mountpath=$(realpath "$1")
+    local deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
+    [[ -d "$mountpath" ]] || fatal 'mountpath does not exist'
+    if deck_isdeck "$mountpath"; then
+        find "$(dirname "$deckdir")" -name 'parent' -print | grep -q "^${mountpath}$" && \
+            fatal 'cannot delete a parent deck'
 
-    deck_ismounted $mountpath && umount $mountpath
-    deck_isdeck $mountpath && rm -rf $deckdir
-    rmdir $mountpath
-    rmdir --ignore-fail-on-non-empty $(dirname $deckdir)
+        deck_ismounted "$mountpath" && umount "$mountpath"
+        rm -rf "$deckdir"
+    fi
+    rmdir "$mountpath"
+    rmdir --ignore-fail-on-non-empty "$(dirname "$deckdir")"
 }
 
 deck_isdirty() {
-    local mountpath=$(realpath $1)
-    local deckdir=$(dirname $mountpath)/.deck/$(basename $mountpath)
-    [ "$(find $deckdir/upper -maxdepth 0 -empty)" ] && return 1
+    local mountpath=$(realpath "$1")
+    local deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
+    [[ -n "$(find "$deckdir/upper" -maxdepth 0 -empty)" ]] && return 1
     return 0
 }
 
 deck_isdeck() {
-    local mountpath=$(realpath $1)
-    local deckdir=$(dirname $mountpath)/.deck/$(basename $mountpath)
-    [ -d $mountpath ] || return 1
-    [ -d $deckdir ] || return 1
-    [ -d $deckdir/work ] || return 255
-    [ -d $deckdir/upper ] || return 255
-    [ -e $deckdir/layers ] || return 255
-    [ -e $deckdir/parent ] || return 255
+    [[ -d "$1" ]] || return 1
+    local mountpath=$(realpath "$1")
+    local deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
+    [[ -d "$mountpath" ]] || return 1
+    [[ -d "$deckdir" ]] || return 1
+    [[ -d "$deckdir/work" ]] || return 255
+    [[ -d "$deckdir/upper" ]] || return 255
+    [[ -e "$deckdir/layers" ]] || return 255
+    [[ -e "$deckdir/parent" ]] || return 255
     return 0
 }
 
 deck_ismounted() {
-    local mountpath=$(realpath $1)
-    [ -d $mountpath ] || fatal "mountpath does not exist"
-    return $(mount |grep -q "^overlay on $mountpath type overlay")
+    local mountpath=$(realpath "$1")
+    [[ -d "$mountpath" ]] || fatal 'mountpath does not exist'
+    mount | grep -q "^overlay on $mountpath type overlay" || return $?
 }
 
 
 opts=()
 args=()
-while [ "$1" != "" ]; do
-    case $1 in
+while [[ -n "$1" ]]; do
+    case "$1" in
         -h|--help)  usage;;
         -*)         opts=("${opts[@]}" "$1");;
         *)          args=("${args[@]}" "$1");;
@@ -130,48 +133,54 @@ while [ "$1" != "" ]; do
 done
 
 [[ ${#args[@]} -eq 0 ]] && usage
-[[ ${#args[@]} -gt 2 ]] && fatal "too many arguments";
-[[ ${#opts[@]} -gt 1 ]] && fatal "conflicting deck options"
-[[ ${#opts[@]} -eq 0 ]] && opts=("--mount")
+[[ ${#args[@]} -gt 2 ]] && fatal 'too many arguments'
+[[ ${#opts[@]} -gt 1 ]] && fatal 'conflicting deck options'
+[[ ${#opts[@]} -eq 0 ]] && opts=('--mount')
 action=${opts[0]}
 
 case $action in
     -u|--umount|-D|--delete|--isdeck|--ismounted|--show-layers)
-        [[ ${#args[@]} -eq 1 ]] || fatal "missing argument";;
+        [[ ${#args[@]} -eq 1 ]] || fatal 'missing argument';;
 esac
 
-[ "$(id -u)" != "0" ] && fatal "must be run as root"
-lsmod |grep -q overlay || fatal "overlay module not loaded"
+[ "$(id -u)" != "0" ] && fatal 'must be run as root'
+lsmod | grep -q overlay || fatal 'overlay module not loaded'
+
+src="${args[0]}"
+maybe_dst="${args[1]}"
 
 case $action in
     -m|--mount)
-        [[ ${#args[@]} -eq 2 ]] && deck_mount ${args[0]} ${args[1]};
-        [[ ${#args[@]} -eq 1 ]] && deck_remount ${args[0]};
+        if [[ -n "$maybe_dst" ]]; then
+            deck_mount "$src" "$maybe_dst"
+        else
+            deck_remount "$src"
+        fi
         ;;
     -u|--umount)
-        deck_umount ${args[0]};
+        deck_umount "$src"
         ;;
     -D|--delete)
-        deck_delete ${args[0]};
+        deck_delete "$src"
         ;;
     --isdeck)
-        exit $(deck_isdeck ${args[0]});
+        exit $(deck_isdeck "$src")
         ;;
     --isdirty)
-        exit $(deck_isdirty ${args[0]});
+        exit $(deck_isdirty "$src")
         ;;
     --ismounted)
-        exit $(deck_ismounted ${args[0]});
+        exit $(deck_ismounted "$src")
         ;;
     --list-layers)
-        deck_isdeck ${args[0]} || fatal "not deck";
-        mountpath=$(realpath ${args[0]});
-        deckdir=$(dirname $mountpath)/.deck/$(basename $mountpath);
-        echo $deckdir/upper;
-        tac $deckdir/layers;
+        deck_isdeck "$src" || fatal "not a deck: $src"
+        mountpath=$(realpath "$src")
+        deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
+        echo "$deckdir/upper"
+        tac "$deckdir/layers"
         ;;
     *)
-        fatal "unrecognized option: $action";
+        fatal "unrecognized option: $action"
         ;;
 esac
 


### PR DESCRIPTION
Closes https://github.com/turnkeylinux/tracker/issues/1094

* all brackets changed to Bash double brackets
* all variables properly quoted
* additional correctness checks for used paths
* can now operate on decks with spaces and special characters in their paths (not that you should)