### PR TITLE
Fix silly bug.

### DIFF
--- a/deck
+++ b/deck
@@ -110,7 +110,7 @@ real_umount() {
                 submounts=$(mount | sed -n "s|.*\($mountpath/[a-zA-Z0-9 /]*\) type.*|\1|p")
                 [[ -n "$submounts" ]] || fatal "Unknown reason for failing 'umount $mountpath'."
                 echo -e "info: Attempting to unmount busy paths:\n$submounts"
-                echo "$submounts" | while read submount; do
+                echo "$submounts" | while read -e submount; do
                     umount "$submount" || fatal "unmounting busy path $submount failed"
                 done
                 umount "$mountpath" || fatal "Cannot unmount $mountpath"

--- a/deck
+++ b/deck
@@ -101,7 +101,7 @@ real_umount() {
     if deck_ismounted "$mountpath"; then
         if [[ "$force" == "yes" ]]; then
             fuser --kill $mountpath || warning "fuser --kill returned non-zero exit code."
-            umount --recursive --force --lazy || fatal "Cannot unmount $mountpath"
+            umount --recursive --force --lazy $mountpath || fatal "Cannot unmount $mountpath"
         else
             processes=$(fuser --mount $mountpath 2>/dev/null) || true
             [[ -z "$processes" ]] || \

--- a/deck
+++ b/deck
@@ -59,7 +59,7 @@ deck_mount() {
     
     if [[ -d "$mountpath" ]]; then
         [[ $(find "$mountpath" -maxdepth 0 -empty) == "$mountpath" ]] || \
-            fatal 'mountpath exists but not empty'
+            fatal "mountpath (${mountpath}) exists but not empty"
     fi
 
     local deckdir="$(dirname "$mountpath")/.deck/$(basename "$mountpath")"
@@ -100,18 +100,18 @@ real_umount() {
     [[ -d "$mountpath" ]] || fatal 'mountpath does not exist'
     if deck_ismounted "$mountpath"; then
         if [[ "$force" == "yes" ]]; then
-            fuser --kill $mountpath || warning "fuser --kill returned non-zero exit code."
-            umount --recursive --force --lazy $mountpath || fatal "Cannot unmount $mountpath"
+            fuser --kill "$mountpath" || warning "fuser --kill returned non-zero exit code."
+            umount --recursive --force --lazy "$mountpath" || fatal "Cannot unmount $mountpath"
         else
-            processes=$(fuser --mount $mountpath 2>/dev/null) || true
+            processes=$(fuser --mount "$mountpath" 2>/dev/null) || true
             [[ -z "$processes" ]] || \
                 fatal "Running processes locking $mountpath, try again with -f|--force to kill"
             if ! umount "$mountpath" >/dev/null 2>&1; then
-                submounts=$(mount | sed -n "s|.*\($mountpath/[a-zA-Z0-9/]*\) .*|\1|p")
+                submounts=$(mount | sed -n "s|.*\($mountpath/[a-zA-Z0-9 /]*\) type.*|\1|p")
                 [[ -n "$submounts" ]] || fatal "Unknown reason for failing 'umount $mountpath'."
                 echo -e "info: Attempting to unmount busy paths:\n$submounts"
-                for submount in $submounts; do
-                    umount $submount || fatal "unmounting busy path $submount failed"
+                echo "$submounts" | while read submount; do
+                    umount "$submount" || fatal "unmounting busy path $submount failed"
                 done
                 umount "$mountpath" || fatal "Cannot unmount $mountpath"
             fi


### PR DESCRIPTION
Minor tweak to fix `deck -D -f /path/to/deck`.

`deck -d /path/to/deck` works fine if no processes are running in the deck. However, if processes are running, you will get an (expected) error message like this:
```
fatal: Running processes locking /path/to/deck, try again with -f|--force to kill
```

However, if `-f|--force` is used, the processes will be killed, but you will then get an error like this:
```
fatal: Cannot unmount /path/to/deck
```

It's because umount is called without the path! Doh!